### PR TITLE
Path Parameter now includes "required: true" as per spec

### DIFF
--- a/src/parameter.rs
+++ b/src/parameter.rs
@@ -147,11 +147,15 @@ pub enum ParameterKind {
 
 impl Parameter {
     fn new_kind(name: String, schema: RefOr<Schema>, kind: ParameterKind) -> Self {
+        let required = match kind {
+            ParameterKind::Path { style: _ } => true,
+            _ => false,
+        };
         Parameter {
             data: ParameterData {
                 name,
                 description: None,
-                required: false,
+                required,
                 deprecated: None,
                 format: ParameterSchemaOrContent::Schema(schema),
                 example: None,


### PR DESCRIPTION
The openAPI spec demands that:

> If the parameter location is "path", this property is REQUIRED and its value MUST be true.

That was formerly not the case.

Thank you for this crate & oasgen! They are incredibly helpful!